### PR TITLE
Local images support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+dockerfile-parse==0.0.13
 taskcluster==7.0.1
 pyyaml==5.1

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -4,7 +4,7 @@ import yaml
 import json
 import taskcluster
 from taskboot.config import Configuration, TASKCLUSTER_DASHBOARD_URL
-from taskboot.docker import Docker
+from taskboot.docker import Docker, patch_dockerfile
 from taskboot.utils import retry
 import logging
 
@@ -103,6 +103,11 @@ def build_compose(target, args):
         logger.info('Building image for service {}'.format(name))
         context = os.path.realpath(os.path.join(root, build.get('context', '.')))
         dockerfile = os.path.realpath(os.path.join(context, build.get('dockerfile', 'Dockerfile')))
+
+        # We need to replace the FROM statements by their local versions
+        # to avoid using the remote repository first
+        patch_dockerfile(dockerfile, docker.list_images())
+
         tag = service.get('image', name)
         if args.registry:
             tag = '{}/{}'.format(args.registry, tag)

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -212,8 +212,7 @@ def patch_dockerfile(dockerfile, images):
     # The FROM statement parsing & replacement is provided
     # by the DockerfileParser
     parser = DockerfileParser()
+    parser.dockerfile_path = dockerfile
     parser.content = open(dockerfile).read()
     logger.info('Initial parent images: {}'.format(' & '.join(parser.parent_images)))
     parser.parent_images = list(map(_find_replacement, parser.parent_images))
-    with open(dockerfile, 'w') as f:
-        f.write(parser.content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+import subprocess
+from taskboot.docker import Docker
+
+
+@pytest.fixture
+def mock_docker(tmpdir):
+    '''
+    Mock the Docker tool class (img) with a fake state
+    '''
+    class MockDocker(Docker):
+        def __init__(self):
+            self.state = None
+            self.images = []
+
+        def run(self, command, **kwargs):
+            # Fake img calls
+            if command[0] == 'ls':
+                # Fake image listing
+                output = 'Headers\n'  # will be skipped by parser
+                output += '\n'.join(['\t'.join(image) for image in self.images])
+                return subprocess.CompletedProcess(
+                    args=command,
+                    returncode=0,
+                    stdout=output.encode('utf-8'),
+                )
+
+            else:
+                raise Exception('Unsupported command in mock: {}'.format(' '.join(command)))
+
+    return MockDocker()

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,0 +1,3 @@
+# TODO: test taskboot.docker.parse_image_name
+# TODO: test taskboot.docker.patch_dockerfile
+# TODO: test taskboot.docker.Docker.list_images

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,3 +1,119 @@
-# TODO: test taskboot.docker.parse_image_name
-# TODO: test taskboot.docker.patch_dockerfile
-# TODO: test taskboot.docker.Docker.list_images
+from taskboot.docker import parse_image_name, patch_dockerfile
+import uuid
+
+DOCKERFILE_SIMPLE = '''
+FROM project/base:latest
+RUN something
+CMD ["test"]
+'''
+DOCKERFILE_STAGES = '''
+FROM project/base:latest as build
+RUN something
+
+FROM project/another:123
+COPY --from=build /src /dest
+CMD ["test"]
+'''
+
+
+def test_parse_image_name():
+    '''
+    Check the Docker image name & tag parser
+    '''
+    assert parse_image_name('nginx') == ('nginx', 'latest')
+    assert parse_image_name('nginx:latest') == ('nginx', 'latest')
+    assert parse_image_name('nginx:v1.2.3') == ('nginx', 'v1.2.3')
+    assert parse_image_name('anotherImage-complicated:some-thing') == ('anotherImage-complicated', 'some-thing')
+    assert parse_image_name('repo/project') == ('repo/project', 'latest')
+    assert parse_image_name('repo/project:latest') == ('repo/project', 'latest')
+    assert parse_image_name('repo/project:1.2') == ('repo/project', '1.2')
+    assert parse_image_name('some/path/to/project') == ('some/path/to/project', 'latest')
+    assert parse_image_name('some/path/to/project:abcd') == ('some/path/to/project', 'abcd')
+    assert parse_image_name('registry.com/repo/project') == ('registry.com/repo/project', 'latest')
+
+
+def test_patch_dockerfile(tmpdir):
+    '''
+    Validate the Dockerfile patch by replacing images names/tags by local images digest
+    '''
+
+    def patch(content, images):
+        dockerfile = tmpdir.join(str(uuid.uuid4()))
+        dockerfile.write(content)
+        patch_dockerfile(str(dockerfile), images)
+        return dockerfile.read()
+
+    # No modifications when no images are provided
+    images = []
+    assert patch(DOCKERFILE_SIMPLE, images) == DOCKERFILE_SIMPLE
+
+    # or the images do not match
+    images = [
+        {'repository': 'another', 'tag': 'latest'}
+    ]
+    assert patch(DOCKERFILE_SIMPLE, images) == DOCKERFILE_SIMPLE
+    images = [
+        {'repository': 'project/base', 'tag': 'v123'}
+    ]
+    assert patch(DOCKERFILE_SIMPLE, images) == DOCKERFILE_SIMPLE
+
+    # Both repository & tag must match
+    images = [
+        {
+            'repository': 'project/base',
+            'tag': 'latest',
+            'digest': 'deadbeef12345',
+            'registry': 'hub.docker.com',
+        }
+    ]
+    assert patch(DOCKERFILE_SIMPLE, images) == '''
+FROM hub.docker.com/project/base@sha256:deadbeef12345
+RUN something
+CMD ["test"]
+'''
+
+    # Multi stages images are supported
+    images = [
+        {
+            'repository': 'project/base',
+            'tag': 'latest',
+            'digest': 'deadbeef12345',
+            'registry': 'hub.docker.com',
+        },
+        {
+            'repository': 'project/another',
+            'tag': '123',
+            'digest': 'coffee67890',
+            'registry': 'registry.mozilla.org',
+        },
+    ]
+    assert patch(DOCKERFILE_STAGES, images) == '''
+FROM hub.docker.com/project/base@sha256:deadbeef12345 AS build
+RUN something
+
+FROM registry.mozilla.org/project/another@sha256:coffee67890
+COPY --from=build /src /dest
+CMD ["test"]
+'''
+
+
+def test_list_local_images(mock_docker):
+    '''
+    Validate local images listing from img state
+    '''
+    assert mock_docker.list_images() == []
+
+    mock_docker.images = [
+        ('registry.com/repo/test:latest', '10.9MiB', '1 days ago', '1 days ago', 'sha256:991d19e5156799aa79cf7138b8b843601f180e68f625b892df40a1993b7ac7da')  # noqa
+    ]
+    assert mock_docker.list_images() == [
+        {
+            'registry': 'registry.com',
+            'repository': 'repo/test',
+            'tag': 'latest',
+            'size': '10.9MiB',
+            'created': '1 days ago',
+            'updated': '1 days ago',
+            'digest': '991d19e5156799aa79cf7138b8b843601f180e68f625b892df40a1993b7ac7da',
+        }
+    ]


### PR DESCRIPTION
Due to https://github.com/genuinetools/img/issues/206, taskboot needs to patch target's Dockerfile when using `build-compose` in order to use local images first, before trying the remote repo.

Just miss unit tests...