### PR TITLE
Add support for build args in build-compose subcommand

### DIFF
--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -51,7 +51,7 @@ def build_image(target, args):
     logger.info('Will produce image {}'.format(tag))
 
     # Build the image
-    docker.build(target.dir, dockerfile, tag)
+    docker.build(target.dir, dockerfile, tag, [])
 
     # Write the produced image
     if output:

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -112,7 +112,7 @@ def build_compose(target, args):
         if args.registry:
             tag = '{}/{}'.format(args.registry, tag)
         retry(
-            lambda: docker.build(context, dockerfile, tag),
+            lambda: docker.build(context, dockerfile, tag, args.build_arg),
             wait_between_retries=1,
             retries=args.build_retries,
         )

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -51,7 +51,7 @@ def build_image(target, args):
     logger.info('Will produce image {}'.format(tag))
 
     # Build the image
-    docker.build(target.dir, dockerfile, tag, [])
+    docker.build(target.dir, dockerfile, tag)
 
     # Write the produced image
     if output:

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -64,7 +64,7 @@ def main():
     build.set_defaults(func=build_image)
 
     # Build images from a docker-compose.yml file
-    compose = commands.add_parser('build-compose', help='Build images from a docker-compose flie')
+    compose = commands.add_parser('build-compose', help='Build images from a docker-compose file')
     compose.add_argument(
         '--compose-file', '-c',
         dest='composefile',
@@ -79,6 +79,12 @@ def main():
         type=int,
         default=3,
         help='Number of times taskbook will retry building each image',
+    )
+    compose.add_argument(
+        '--build-arg',
+        type=str,
+        action='append',
+        help='Docker build args passed for each builded service',
     )
     compose.set_defaults(func=build_compose)
 

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -84,7 +84,7 @@ class Docker(Tool):
                 logger.warn('Did not parse this image: {}'.format(line))
         return out
 
-    def build(self, context_dir, dockerfile, tag, build_args):
+    def build(self, context_dir, dockerfile, tag, build_args=[]):
         logger.info('Building docker image {}'.format(dockerfile))
 
         command = [
@@ -97,8 +97,7 @@ class Docker(Tool):
 
         # We need to "de-parse" the build args
         for single_build_arg in build_args:
-            command.append("--build-arg")
-            command.append(single_build_arg)
+            command += ['--build-arg', single_build_arg]
 
         command.append(context_dir)
 

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -84,16 +84,25 @@ class Docker(Tool):
                 logger.warn('Did not parse this image: {}'.format(line))
         return out
 
-    def build(self, context_dir, dockerfile, tag):
+    def build(self, context_dir, dockerfile, tag, build_args):
         logger.info('Building docker image {}'.format(dockerfile))
-        self.run([
+
+        command = [
             'build',
             '--state', self.state,
             '--no-console',
             '--tag', tag,
             '--file', dockerfile,
-            context_dir,
-        ])
+        ]
+
+        # We need to "de-parse" the build args
+        for single_build_arg in build_args:
+            command.append("--build-arg")
+            command.append(single_build_arg)
+
+        command.append(context_dir)
+
+        self.run(command)
         logger.info('Built image {}'.format(tag))
 
     def save(self, tag, path):


### PR DESCRIPTION
Build args are global for all the services, users will need to handle
namespacing themselves.