### PR TITLE
Add support for an exclude filter in push-artifact subcommand

### DIFF
--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -96,6 +96,11 @@ def main():
         default='public/**.tar',
         help='Filter applied to artifacts paths, supports fnmatch syntax.',
     )
+    artifacts.add_argument(
+        '--exclude-filter',
+        type=str,
+        help='If an artifact match the exclude filter it won\'t be uploaded, supports fnmatch syntax.',
+    )
     artifacts.set_defaults(func=push_artifacts)
 
     # Ensure the given hook is up-to-date with the given definition

--- a/taskboot/push.py
+++ b/taskboot/push.py
@@ -45,7 +45,7 @@ def push_artifacts(target, args):
             artifact_name = artifact['name']
             if fnmatch(artifact_name, args.artifact_filter):
 
-                if args.exclude_filter and fnmatch(artifact_name, args.artifact_filter):
+                if args.exclude_filter and fnmatch(artifact_name, args.exclude_filter):
                     logger.info('Excluding artifact %s because of exclude filter', artifact_name)
                     continue
 

--- a/taskboot/push.py
+++ b/taskboot/push.py
@@ -47,6 +47,7 @@ def push_artifacts(target, args):
 
                 if args.exclude_filter and fnmatch(artifact_name, args.artifact_filter):
                     logger.info('Excluding artifact %s because of exclude filter', artifact_name)
+                    continue
 
                 push_artifact(queue, skopeo, task_id, artifact_name)
 

--- a/taskboot/push.py
+++ b/taskboot/push.py
@@ -42,8 +42,13 @@ def push_artifacts(target, args):
 
         # Only process the filtered artifacts
         for artifact in task_artifacts['artifacts']:
-            if fnmatch(artifact['name'], args.artifact_filter):
-                push_artifact(queue, skopeo, task_id, artifact['name'])
+            artifact_name = artifact['name']
+            if fnmatch(artifact_name, args.artifact_filter):
+
+                if args.exclude_filter and fnmatch(artifact_name, args.artifact_filter):
+                    logger.info('Excluding artifact %s because of exclude filter', artifact_name)
+
+                push_artifact(queue, skopeo, task_id, artifact_name)
 
     logger.info('All found artifacts were pushed.')
 


### PR DESCRIPTION
We have the use in the Mozilla bugbug project where we want to build a Docker
image but don't push it in a first time.