### PR TITLE
Fix default Docker build args

### DIFF
--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -90,6 +90,7 @@ def main():
     compose.add_argument(
         '--build-arg',
         type=str,
+        default=[],
         action='append',
         help='Docker build args passed for each built service',
     )


### PR DESCRIPTION
When testing locally and without this patch, I got the following traceback:

```
Traceback (most recent call last):
  File ".../bin/taskboot", line 11, in <module>
    load_entry_point('task-boot', 'console_scripts', 'taskboot')()
  File ".../task-boot/taskboot/cli.py", line 146, in main
    args.func(target, args)
  File ".../task-boot/taskboot/build.py", line 122, in build_compose
    retries=args.build_retries,
  File ".../task-boot/taskboot/utils.py", line 20, in retry
    return operation()
  File ".../task-boot/taskboot/build.py", line 120, in <lambda>
    lambda: docker.build(context, dockerfile, tag, args.build_arg),
  File ".../task-boot/taskboot/docker.py", line 99, in build
    for single_build_arg in build_args:
TypeError: 'NoneType' object is not iterable
```