### PR TITLE
Add support for additional tags when building

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -87,7 +87,7 @@ tasks:
           - "apk add git img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing --quiet &&
             git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b taskboot &&
             pip install --quiet . &&
-            taskboot --target=/src build --image=$IMAGE --registry=$REGISTRY --tag=$VERSION --write /image.tar Dockerfile"
+            taskboot --target=/src build --image=$IMAGE --tag=$VERSION --write /image.tar Dockerfile"
         artifacts:
           public/taskboot/image.tar:
             expires: {$fromNow: '2 weeks'}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -75,7 +75,8 @@ tasks:
         maxRunTime: 3600
         image: python:3-alpine
         env:
-          TAG: registry.hub.docker.com/mozilla/taskboot
+          IMAGE: mozilla/taskboot
+          REGISTRY: registry.hub.docker.com
           VERSION:
             $if: 'head_branch[:10] == "refs/tags/"'
             then: {$eval: 'head_branch[10:]' }
@@ -86,7 +87,7 @@ tasks:
           - "apk add git img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing --quiet &&
             git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b taskboot &&
             pip install --quiet . &&
-            taskboot --target=/src build --tag=$TAG:$VERSION --write /image.tar Dockerfile"
+            taskboot --target=/src build --image=$IMAGE --registry=$REGISTRY --tag=$VERSION --write /image.tar Dockerfile"
         artifacts:
           public/taskboot/image.tar:
             expires: {$fromNow: '2 weeks'}

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -54,10 +54,15 @@ def build_image(target, args):
 
     # Build the tags
     base_image = args.image or 'taskboot-{}'.format(uuid.uuid4())
+    tags = gen_docker_images(base_image, args.tag, args.registry)
 
     if args.push:
         assert config.has_docker_auth(), 'Missing Docker authentication'
         registry = config.docker['registry']
+
+        if registry != args.registry:
+            msg = "The credentials are the ones for %r not %r"
+            logger.warning(msg, registry, args.registry)
 
         # Login on docker
         docker.login(
@@ -65,10 +70,6 @@ def build_image(target, args):
             config.docker['username'],
             config.docker['password'],
         )
-
-        tags = gen_docker_images(base_image, args.tag, registry)
-    else:
-        tags = gen_docker_images(base_image, args.tag, args.registry)
 
     # Build the image
     docker.build(target.dir, dockerfile, tags, args.build_arg)

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -114,10 +114,19 @@ def build_compose(target, args):
         patch_dockerfile(dockerfile, docker.list_images())
 
         tag = service.get('image', name)
+
+        additional_tags = []
+
+        if args.additional_tag:
+            # Remove any existing tag
+            tagless_image = tag.rsplit(":", 1)
+            new_image = f"{tagless_image[0]}:{args.additional_tag}"
+            additional_tags.append(new_image)
+
         if args.registry:
             tag = '{}/{}'.format(args.registry, tag)
         retry(
-            lambda: docker.build(context, dockerfile, tag, args.build_arg),
+            lambda: docker.build(context, dockerfile, tag, additional_tags, args.build_arg),
             wait_between_retries=1,
             retries=args.build_retries,
         )

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -68,7 +68,7 @@ def build_image(target, args):
 
         tags = gen_docker_images(base_image, args.tag, registry)
     else:
-        tags = gen_docker_images(base_image, args.tag)
+        tags = gen_docker_images(base_image, args.tag, args.registry)
 
     # Build the image
     docker.build(target.dir, dockerfile, tags, args.build_arg)

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -11,6 +11,27 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def gen_docker_images(docker_image_name, tags=None, registry=None):
+    if not tags:
+        tags = ["latest"]
+
+    # Remove any potential existing tag
+    tagless_image = docker_image_name.rsplit(":", 1)[0]
+
+    result = []
+
+    for tag in tags:
+        if registry and not tagless_image.startswith(registry):
+            full_tag = "{}/{}:{}".format(registry, tagless_image, tag)
+        else:
+            full_tag = "{}:{}".format(tagless_image, tag)
+
+        logger.info('Will produce image {}'.format(full_tag))
+        result.append(full_tag)
+
+    return result
+
+
 def build_image(target, args):
     '''
     Build a docker image and allow save/push
@@ -31,29 +52,12 @@ def build_image(target, args):
         assert os.access(os.path.dirname(output), os.W_OK | os.W_OK), \
             'Destination is not writable'
 
-    # Build the tag
-    full_docker_images_names = []
-
+    # Build the tags
     base_image = args.image or 'taskboot-{}'.format(uuid.uuid4())
-    tags = args.tag or ["latest"]
-    for tag in tags:
-        # TODO: Should we check if args.image contains a tag?
-        full_tag = '{}:{}'.format(base_image, tag)
-        full_docker_images_names.append(full_tag)
-        logger.info('Will produce image {}'.format(full_tag))
 
     if args.push:
         assert config.has_docker_auth(), 'Missing Docker authentication'
         registry = config.docker['registry']
-
-        # Update tags to include the registry
-        new_tags = []
-
-        for tag in full_docker_images_names:
-            if not tag.startswith(registry):
-                new_tags.append('{}/{}'.format(registry, tag))
-
-        full_docker_images_names = new_tags
 
         # Login on docker
         docker.login(
@@ -62,16 +66,22 @@ def build_image(target, args):
             config.docker['password'],
         )
 
+        tags = gen_docker_images(base_image, args.tag, registry)
+    else:
+        tags = gen_docker_images(base_image, args.tag)
+
     # Build the image
-    docker.build(target.dir, dockerfile, full_docker_images_names, args.build_arg)
+    docker.build(target.dir, dockerfile, tags, args.build_arg)
 
     # Write the produced image
     if output:
-        docker.save(tag, output)
+        for tag in tags:
+            docker.save(tag, output)
 
     # Push the produced image
     if args.push:
-        docker.push(tag)
+        for tag in tags:
+            docker.push(tag)
 
 
 def build_compose(target, args):
@@ -125,17 +135,9 @@ def build_compose(target, args):
         # to avoid using the remote repository first
         patch_dockerfile(dockerfile, docker.list_images())
 
-        tags = []
         docker_image = service.get('image', name)
-        # Remove any existing tag
-        tagless_image = docker_image.rsplit(":", 1)[0]
+        tags = gen_docker_images(docker_image, args.tag, args.registry)
 
-        for tag in (args.tag or ['latest']):
-            new_image = f"{tagless_image}:{tag}"
-            tags.append(new_image)
-
-        if args.registry:
-            tag = '{}/{}'.format(args.registry, tag)
         retry(
             lambda: docker.build(context, dockerfile, tags, args.build_arg),
             wait_between_retries=1,
@@ -144,7 +146,8 @@ def build_compose(target, args):
 
         # Write the produced image
         if output:
-            docker.save(tag, os.path.join(output, '{}.tar'.format(name)))
+            for tag in tags:
+                docker.save(tag, os.path.join(output, '{}.tar'.format(name)))
 
     logger.info('Compose file fully processed.')
 

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -61,7 +61,12 @@ def main():
         help='Push after building on configured repository',
     )
     build.add_argument('--image', type=str, help='The docker image without tag, default to a random one')
-    build.add_argument('--registry', type=str, help='Docker registry to use in images tags')
+    build.add_argument(
+        '--registry',
+        type=str,
+        default=os.environ.get('REGISTRY'),
+        help='Docker registry to use in images tags'
+    )
     build.add_argument(
         '--tag',
         type=str,

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -60,7 +60,14 @@ def main():
         default=False,
         help='Push after building on configured repository',
     )
-    build.add_argument('--tag', type=str, help='Use a specific tag on this image')
+    build.add_argument('--image', type=str, help='The docker image without tag, default to a random one')
+    build.add_argument(
+        '--tag',
+        type=str,
+        action='append',
+        default=[],
+        help='Use a specific tag on this image, default to latest tag'
+    )
     build.add_argument(
         '--build-arg',
         type=str,
@@ -102,9 +109,11 @@ def main():
         help='Build only the specific compose service'
     )
     compose.add_argument(
-        '--additional-tag',
+        '--tag',
         type=str,
-        help='An additional tag to use, images will be tagged with it and pushed',
+        action='append',
+        default=[],
+        help='Use a specific tag on this image, default to latest tag'
     )
     compose.set_defaults(func=build_compose)
 

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -61,6 +61,7 @@ def main():
         help='Push after building on configured repository',
     )
     build.add_argument('--image', type=str, help='The docker image without tag, default to a random one')
+    build.add_argument('--registry', type=str, help='Docker registry to use in images tags')
     build.add_argument(
         '--tag',
         type=str,

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -101,6 +101,11 @@ def main():
         default=[],
         help='Build only the specific compose service'
     )
+    compose.add_argument(
+        '--additional-tag',
+        type=str,
+        help='An additional tag to use, images will be tagged with it and pushed',
+    )
     compose.set_defaults(func=build_compose)
 
     # Push docker images produced in other tasks

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -84,18 +84,17 @@ class Docker(Tool):
                 logger.warn('Did not parse this image: {}'.format(line))
         return out
 
-    def build(self, context_dir, dockerfile, tag, additional_tags=[], build_args=[]):
+    def build(self, context_dir, dockerfile, tags, build_args=[]):
         logger.info('Building docker image {}'.format(dockerfile))
 
         command = [
             'build',
             '--state', self.state,
             '--no-console',
-            '--tag', tag,
             '--file', dockerfile,
         ]
 
-        for add_tag in additional_tags:
+        for add_tag in tags:
             command += ["--tag", add_tag]
 
         # We need to "de-parse" the build args
@@ -103,6 +102,8 @@ class Docker(Tool):
             command += ['--build-arg', single_build_arg]
 
         command.append(context_dir)
+
+        logger.info('Running img command: {}'.format(command))
 
         self.run(command)
         logger.info('Built image {}'.format(tag))

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -106,7 +106,7 @@ class Docker(Tool):
         logger.info('Running img command: {}'.format(command))
 
         self.run(command)
-        logger.info('Built image {}'.format(tag))
+        logger.info('Built image {}'.format(", ".join(tags)))
 
     def save(self, tag, path):
         logger.info('Saving image {} to {}'.format(tag, path))

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -84,7 +84,7 @@ class Docker(Tool):
                 logger.warn('Did not parse this image: {}'.format(line))
         return out
 
-    def build(self, context_dir, dockerfile, tag, build_args=[]):
+    def build(self, context_dir, dockerfile, tag, additional_tags=[], build_args=[]):
         logger.info('Building docker image {}'.format(dockerfile))
 
         command = [
@@ -94,6 +94,9 @@ class Docker(Tool):
             '--tag', tag,
             '--file', dockerfile,
         ]
+
+        for add_tag in additional_tags:
+            command += ["--tag", add_tag]
 
         # We need to "de-parse" the build args
         for single_build_arg in build_args:


### PR DESCRIPTION
The use-case is the following:
- The docker-compose contains images untagged or tagged with `latest`. We want
  those images and push them.
- We also to pushed tagged images with the git tag. The git tag is known only
  at runtime.

Add the `--additional-tags` that will takes the image name from docker-compose
and add or replace the tag by the given CLI argument and add this as a new
tag. `push-artifacts` should handle those additional tags without issues.