### PR TITLE
Update the heroku command to being able to allow atomic deloy

### DIFF
--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -178,25 +178,14 @@ def main():
         help='Taskcluster task group to analyse',
     )
     deploy_heroku.add_argument(
-        '--artifact-filter',
-        type=str,
-        help='Filter applied to artifacts paths, supports fnmatch syntax.',
-        required=True,
-    )
-    deploy_heroku.add_argument(
-        '--exclude-filter',
-        type=str,
-        help='If an artifact match the exclude filter it won\'t be uploaded, supports fnmatch syntax.',
-    )
-    deploy_heroku.add_argument(
         '--heroku-app',
         type=str,
         required=True,
     )
     deploy_heroku.add_argument(
-        '--heroku-dyno-type',
-        type=str,
-        default='web',
+        'artifacts',
+        nargs='+',
+        help='the mapping of worker-type:artifact-path to deploy'
     )
     deploy_heroku.set_defaults(func=heroku_release)
 

--- a/taskboot/push.py
+++ b/taskboot/push.py
@@ -73,35 +73,41 @@ def heroku_release(target, args):
     # Load queue service
     queue = taskcluster.Queue(config.get_taskcluster_options())
 
-    # Get the list of matching artifacts as we should get only one
-    matching_artifacts = load_artifacts(args.task_id, queue, args.artifact_filter, args.exclude_filter)
+    updates_payload = []
 
-    # Push the Docker image
-    if len(matching_artifacts) == 0:
-        raise ValueError(f"No artifact found for {args.artifact_filter}")
-    elif len(matching_artifacts) > 1:
-        raise ValueError(f"More than one artifact found for {args.artifact_filter}: {matching_artifacts!r}")
-    else:
+    for artifact in args.artifacts:
+        heroku_dyno_type, artifact_path = artifact.split(":", 1)
+        logger.info("Searching artifact for dyno type %r with filter %r", heroku_dyno_type, artifact_path)
+
+        # Get the list of matching artifacts as we should get only one
+        matching_artifacts = load_artifacts(args.task_id, queue, artifact_path)
+
+        # Check that we only got one matching artifact
+        if len(matching_artifacts) == 0:
+            raise ValueError(f"No artifact found for {artifact_path}")
+        elif len(matching_artifacts) > 1:
+            raise ValueError(f"More than one artifact found for {artifact_path}: {matching_artifacts!r}")
+
+        # Push the Docker image
         task_id, artifact_name = matching_artifacts[0]
 
-        custom_tag_name = f"{HEROKU_REGISTRY}/{args.heroku_app}/{args.heroku_dyno_type}"
+        custom_tag_name = f"{HEROKU_REGISTRY}/{args.heroku_app}/{heroku_dyno_type}"
 
         artifact_path = download_artifact(queue, task_id, artifact_name)
 
         skopeo.push_archive(artifact_path, custom_tag_name)
 
-    # Get the Docker image id
-    image_id = docker_id_archive(artifact_path)
+        # Get the Docker image id
+        image_id = docker_id_archive(artifact_path)
+
+        updates_payload.append({"type": heroku_dyno_type, "docker_image": image_id})
 
     # Trigger a release on Heroku
-    logger.info(f"Deploying image id {image_id!r} to Heroku app {args.heroku_app!r} dyno {args.heroku_dyno_type!r}")
-    update = dict(
-        type=args.heroku_dyno_type,
-        docker_image=image_id,
-    )
+    logger.info("Deploying update for dyno types: %r", list(sorted(x["type"] for x in updates_payload)))
+
     r = requests.patch(
             f'https://api.heroku.com/apps/{args.heroku_app}/formation',
-            json=dict(updates=[update]),
+            json=updates_payload,
             headers={
                 'Accept': 'application/vnd.heroku+json; version=3.docker-releases',
                 'Authorization': f"Bearer {config.heroku['password']}",

--- a/taskboot/push.py
+++ b/taskboot/push.py
@@ -82,22 +82,22 @@ def heroku_release(target, args):
 
     parsed_args = []
 
-    bad_parameter_error_message = f"%r doesn't match format 'dyno-name:/path/to/artifact'"
+    bad_parameter_error_message = "{!r} doesn't match format 'dyno-name:/path/to/artifact'"
 
     # Check format of artifacts params
     for artifact in args.artifacts:
         colon_number = artifact.count(":")
 
         if colon_number != 1:
-            raise Exception(bad_parameter_error_message % artifact)
+            raise Exception(bad_parameter_error_message.format(artifact))
 
         heroku_dyno_name, artifact_path = artifact.split(":", 1)
 
         if not heroku_dyno_name:
-            raise Exception(bad_parameter_error_message % artifact)
+            raise Exception(bad_parameter_error_message.format(artifact))
 
         if not artifact_path:
-            raise Exception(bad_parameter_error_message % artifact)
+            raise Exception(bad_parameter_error_message.format(artifact))
 
         parsed_args.append((heroku_dyno_name, artifact_path))
 


### PR DESCRIPTION
The previous version only allowed to deploy one dyno type at a time. For
projects with multiple dyno type, it is problematic.

This change is backward incompatible and replace the old CLI api with a new
one allowing to pass multiple dyno-type:artifact mapping. For example:

```
taskboot deploy-heroku --heroku-app bugbug \
    "web:public/bugbug/bugbug-http-service.tar" \
    "worker:public/bugbug/bugbug-http-service-bg-worker.tar"
```

All the artifact are retrieves pushed and then only one call is made to Heroku
API to deploy them atomically.