### PR TITLE
Bug 1578593 - use taskcluster-urls to generate UI link

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party = taskboot
-known_third_party = boto3,botocore,dockerfile_parse,pytest,requests,setuptools,taskcluster,twine,yaml
+known_third_party = boto3,botocore,dockerfile_parse,pytest,requests,setuptools,taskcluster,taskcluster_urls,twine,yaml
 force_single_line = True
 default_section=FIRSTPARTY
 line_length=159

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3>=1.9
 dockerfile-parse==0.0.15
 taskcluster==16.2.0
+taskcluster-urls==11.0.0
 twine==1.13.0
 pyyaml==5.1.2

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -9,9 +9,9 @@ import os.path
 import uuid
 
 import taskcluster
+import taskcluster_urls
 import yaml
 
-from taskboot.config import TASKCLUSTER_DASHBOARD_URL
 from taskboot.config import Configuration
 from taskboot.docker import Docker
 from taskboot.docker import Img
@@ -205,7 +205,7 @@ def build_hook(target, args):
         hooks.createHook(hook_group_id, hook_id, payload)
         logger.info("Hook %s was successfully created", hook_name)
 
-    hook_url = "{}/hooks/{}/{}".format(
-        TASKCLUSTER_DASHBOARD_URL, hook_group_id, hook_id
+    hook_url = taskcluster_urls.ui(
+        config.get_root_url(), "hooks/{}/{}".format(hook_group_id, hook_id)
     )
     logger.info("Hook URL for debugging: %r", hook_url)

--- a/taskboot/config.py
+++ b/taskboot/config.py
@@ -12,7 +12,6 @@ import yaml
 logger = logging.getLogger(__name__)
 
 TASKCLUSTER_DEFAULT_URL = "https://taskcluster.net"
-TASKCLUSTER_DASHBOARD_URL = "https://tools.taskcluster.net"
 
 
 class Configuration(object):
@@ -30,6 +29,11 @@ class Configuration(object):
         if key in self.config:
             return self.config[key]
         raise KeyError
+
+    def get_root_url(self):
+        if 'TASKCLUSTER_ROOT_URL' in os.environ:
+            return os.environ['TASKCLUSTER_ROOT_URL']
+        return TASKCLUSTER_DEFAULT_URL
 
     def get_taskcluster_options(self):
         """

--- a/taskboot/config.py
+++ b/taskboot/config.py
@@ -31,8 +31,8 @@ class Configuration(object):
         raise KeyError
 
     def get_root_url(self):
-        if 'TASKCLUSTER_ROOT_URL' in os.environ:
-            return os.environ['TASKCLUSTER_ROOT_URL']
+        if "TASKCLUSTER_ROOT_URL" in os.environ:
+            return os.environ["TASKCLUSTER_ROOT_URL"]
         return TASKCLUSTER_DEFAULT_URL
 
     def get_taskcluster_options(self):


### PR DESCRIPTION
This should generate the correct URL regardless of rootUrl.