### PR TITLE
Update .taskcluster.yml for community cluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -25,8 +25,8 @@ tasks:
       else: ${event.repository.html_url}
   in:
     - taskId: {$eval: as_slugid("code_checks")}
-      provisionerId: aws-provisioner-v1
-      workerType: github-worker
+      provisionerId: proj-relman
+      workerType: ci
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
       extra:
@@ -57,8 +57,8 @@ tasks:
     - taskId: {$eval: as_slugid("docker_build")}
       dependencies:
         - {$eval: as_slugid("code_checks")}
-      provisionerId: aws-provisioner-v1
-      workerType: releng-svc
+      provisionerId: proj-relman
+      workerType: ci
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
       extra:
@@ -105,8 +105,8 @@ tasks:
         taskId: {$eval: as_slugid("docker_push")}
         dependencies:
           - {$eval: as_slugid("docker_build")}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: proj-relman
+        workerType: ci
         created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
         extra:


### PR DESCRIPTION
(context: [bug 1574665](https://bugzilla.mozilla.org/show_bug.cgi?id=1574665))

We'll still need to make the secrets in the new deployment in order for this to work but that is blocked on [bug 1593896](https://bugzilla.mozilla.org/show_bug.cgi?id=1593896) at the moment. I wanted to get this up for review to see if it made sense to you all. @La0 and @marco-c in particular.

*Note: this will fail until the github app that provides tc is switched which we would do right before we land this.*

