### PR TITLE
Revert "Use Taskcluster root url environment variable"

### DIFF
--- a/taskboot/config.py
+++ b/taskboot/config.py
@@ -11,9 +11,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-TASKCLUSTER_DEFAULT_URL = os.environ.get(
-    "TASKCLUSTER_ROOT_URL", "https://taskcluster.net"
-)
+TASKCLUSTER_DEFAULT_URL = "https://taskcluster.net"
 
 
 class Configuration(object):


### PR DESCRIPTION
Reverts mozilla/task-boot#77

We were already using it in get_root_url.