### PR TITLE
Retry reading daemon output on ReadError

### DIFF
--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import time
 
 import docker as really_old_docker
 from dockerfile_parse import DockerfileParser
@@ -368,6 +369,7 @@ class DinD(Tool):
                     raise Exception(
                         "Failed to build the docker image, too many read errors"
                     )
+                time.sleep(i)
                 continue
 
             # If we reach past the inner loop without hitting the Read exception


### PR DESCRIPTION
To avoid [this intermittent issue](https://community-tc.services.mozilla.com/tasks/GfbFp-cxTPW4XF376MSmNw/runs/1/logs/live/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FGfbFp-cxTPW4XF376MSmNw%2Fruns%2F1%2Fartifacts%2Fpublic%2Flogs%2Flive.log) from the remote docker daemon