### PR TITLE
Rename Git auth function to explain it is not strictly related to GitHub

### DIFF
--- a/taskboot/config.py
+++ b/taskboot/config.py
@@ -82,11 +82,11 @@ class Configuration(object):
             return False
         return "username" in pypi and "password" in pypi
 
-    def has_github_auth(self):
-        github = self.config.get("github")
-        if github is None:
+    def has_git_auth(self):
+        git = self.config.get("github")
+        if git is None:
             return False
-        return "token" in github
+        return "token" in git
 
     def has_cargo_auth(self):
         cargo = self.config.get("cargo")

--- a/taskboot/config.py
+++ b/taskboot/config.py
@@ -83,7 +83,7 @@ class Configuration(object):
         return "username" in pypi and "password" in pypi
 
     def has_git_auth(self):
-        git = self.config.get("github")
+        git = self.config.get("git")
         if git is None:
             return False
         return "token" in git

--- a/taskboot/git.py
+++ b/taskboot/git.py
@@ -18,7 +18,7 @@ def git_push(target, args):
 
     # Load config from file/secret
     config = Configuration(args)
-    assert config.has_github_auth(), "Missing GitHub authentication"
+    assert config.has_git_auth(), "Missing Git authentication"
 
     # Set remote repository
     repo_link = "https://{}:{}@{}.git".format(

--- a/taskboot/github.py
+++ b/taskboot/github.py
@@ -74,7 +74,7 @@ def github_release(target, args):
 
     # Load config from file/secret
     config = Configuration(args)
-    assert config.has_github_auth(), "Missing Github authentication"
+    assert config.has_git_auth(), "Missing Github authentication"
 
     # Check if local or dependent task assets are used
     if args.local_asset is None:


### PR DESCRIPTION
The `has_github_auth` has been renamed to `has_git_auth`. We need to change the token name in the `yml` file also.

Thanks in advance for your review! :)