### PR TITLE
Install the latest Rust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.7-alpine
 RUN apk add --no-cache img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 # Setup other deps
-RUN apk add --no-cache git skopeo docker ca-certificates gcc
+RUN apk add --no-cache git skopeo docker ca-certificates gcc g++
 
 # Rust environment variables
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,29 @@ FROM python:3.7-alpine
 RUN apk add --no-cache img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 # Setup other deps
-RUN apk add --no-cache git skopeo docker cargo
+RUN apk add --no-cache git skopeo docker ca-certificates gcc
+
+# Rust environment variables
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.49.0
+
+# Install latest Rust version with rustup-init
+RUN set -eux; \
+    apkArch="$(apk --print-arch)"; \
+    case "$apkArch" in \
+        x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='05c5c05ec76671d73645aac3afbccf2187352fce7e46fc85be859f52a42797f6' ;; \
+        aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='6a8a480d8d9e7f8c6979d7f8b12bc59da13db67970f7b13161ff409f0a771213' ;; \
+        *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME;
 
 # Define the working directory
 WORKDIR taskboot


### PR DESCRIPTION
Some software, like `rust-code-analysis`, requires the latest Rust version to be compiled. The Rust packages from `apk` are currently blocked at `Rust 1.47`.