### PR TITLE
Check whether a crate has already been published

### DIFF
--- a/taskboot/cargo.py
+++ b/taskboot/cargo.py
@@ -30,7 +30,13 @@ def cargo_publish(target: Target, args: argparse.Namespace) -> None:
     proc = subprocess.run(
         ["cargo", "publish", "--no-verify", "--token", config.cargo["token"]],
         capture_output=True,
+        text=True,  # Return stdout and stderr output as strings
     )
 
-    if proc.returncode != 0:
+    # If an error is occurred while publishing the crate
+    # Do not fail when a `crate already uploaded` error is found and
+    # the option to ignore that kind of error is enabled
+    if proc.returncode != 0 and not (
+        args.ignore_published and "is already uploaded" in proc.stderr
+    ):
         raise Exception("Failed to publish the crate on crates.io")

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -337,6 +337,11 @@ def main() -> None:
     cargo_publish_cmd = commands.add_parser(
         "cargo-publish", help="Publish a crate on crates.io"
     )
+    cargo_publish_cmd.add_argument(
+        "--ignore-published",
+        action="store_true",
+        help="Do not fail if a crate is already published on crates.io",
+    )
     cargo_publish_cmd.set_defaults(func=cargo_publish)
 
     # Always load the target


### PR DESCRIPTION
This PR checks whether a crate has already been published on `crates.io` before running the `cargo publish` command. 

Thanks in advance for your review! :)