### PR TITLE
Add support for podman.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM python:3.10-alpine
 RUN apk add --no-cache img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 # Setup other deps
-RUN apk add --no-cache git skopeo docker cargo
+RUN apk add --no-cache git skopeo docker cargo podman cni-plugins fuse-overlayfs \
+    && sed -i 's/^#mount_program/mount_program/' /etc/containers/storage.conf
 
 # Define the working directory
 WORKDIR taskboot

--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -16,6 +16,7 @@ from taskboot.config import Configuration
 from taskboot.docker import DinD
 from taskboot.docker import Docker
 from taskboot.docker import Img
+from taskboot.docker import Podman
 from taskboot.docker import patch_dockerfile
 from taskboot.utils import retry
 from taskboot.utils import zstd_compress
@@ -55,6 +56,8 @@ def build_image(target, args):
         build_tool = Img(cache=args.cache)
     elif args.build_tool == "docker":
         build_tool = Docker()
+    elif args.build_tool == "podman":
+        build_tool = Podman()
     elif args.build_tool == "dind":
         build_tool = DinD()
     else:

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -100,7 +100,7 @@ def main() -> None:
     build.add_argument(
         "--build-tool",
         dest="build_tool",
-        choices=["img", "docker", "dind"],
+        choices=["img", "docker", "dind", "podman"],
         default=os.environ.get("BUILD_TOOL") or "img",
         help="Tool to build docker images.",
     )
@@ -205,7 +205,7 @@ def main() -> None:
     artifacts.add_argument(
         "--push-tool",
         dest="push_tool",
-        choices=["skopeo", "docker"],
+        choices=["skopeo", "docker", "podman"],
         default=os.environ.get("PUSH_TOOL") or "skopeo",
         help="Tool to push docker images.",
     )

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -462,7 +462,7 @@ class Skopeo(Tool):
                 "copy",
                 "--authfile",
                 self.auth_file,
-                "oci-archive:{}".format(path),
+                "docker-archive:{}".format(path),
                 "docker://{}".format(tag),
             ]
             self.run(cmd)

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -397,6 +397,26 @@ class DinD(Tool):
         raise NotImplementedError("Cannot push using dind")
 
 
+class Podman(Docker):
+    """
+    Interface to the podman tool, replacing docker daemon
+    """
+
+    def __init__(self):
+        Tool.__init__(self, "podman")
+
+    def list_images(self):
+        """
+        List images stored in current state
+        Parses the text output into usable dicts
+        """
+        result = super().list_images()
+        for image in result:
+            if image["digest"].startswith("sha256:"):
+                image["digest"] = image["digest"][7:]
+        return result
+
+
 class Skopeo(Tool):
     """
     Interface to the skopeo tool, used to copy local images to remote repositories

--- a/taskboot/push.py
+++ b/taskboot/push.py
@@ -11,6 +11,7 @@ import taskcluster
 
 from taskboot.config import Configuration
 from taskboot.docker import Docker
+from taskboot.docker import Podman
 from taskboot.docker import Skopeo
 from taskboot.docker import docker_id_archive
 from taskboot.utils import download_artifact
@@ -37,6 +38,8 @@ def push_artifacts(target, args):
         push_tool = Skopeo()
     elif args.push_tool == "docker":
         push_tool = Docker()
+    elif args.push_tool == "podman":
+        push_tool = Podman()
     else:
         raise ValueError("Not  supported push tool: {}".format(args.push_tool))
 


### PR DESCRIPTION
This is a drop-in replacement for docker, although it still requires `--privileged` like `img`.

`img` is not maintained (see https://github.com/genuinetools/img/issues/348)