### PR TITLE
Revert #377

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -85,6 +85,8 @@ tasks:
             expires: {$fromNow: '2 weeks'}
             path: /image.tar.zst
             type: file
+      scopes:
+        - docker-worker:capability:privileged
       metadata:
         name: TaskBoot docker build
         description: Taskcluster boot utilities - build latest docker image


### PR DESCRIPTION
PR #377 was created when we migrated from Docker Worker to Generic Worker, removing an unneeded scope. However, since we reverted back to Docker Worker, that scope is needed again. This reinstates the scope that was previously removed.