### PR TITLE
chore: update task dependency to podman docker build

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -114,7 +114,7 @@ tasks:
       then:
         taskId: {$eval: as_slugid("docker_push")}
         dependencies:
-          - {$eval: as_slugid("docker_build")}
+          - {$eval: as_slugid("docker_build_podman")}
         provisionerId: proj-relman
         workerType: generic-worker-ubuntu-22-04
         created: {$fromNow: ''}


### PR DESCRIPTION
This should've been changed in https://github.com/mozilla/task-boot/pull/390, sorry about that!

This caused https://github.com/mozilla/task-boot/commit/d8bb92548b64bdeab4565510e48b712f09e95b09#commitcomment-127879799.