### PR TITLE
fix(release): separate out a release docker build from a test docker build

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -55,7 +55,44 @@ tasks:
         owner: bastien@mozilla.com
         source: https://github.com/mozilla/task-boot
 
-    - taskId: {$eval: as_slugid("docker_build_podman")}
+    - taskId: {$eval: as_slugid("docker_build")}
+      dependencies:
+        - {$eval: as_slugid("code_checks")}
+      provisionerId: proj-relman
+      workerType: generic-worker-ubuntu-22-04
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 hour'}
+      payload:
+        capabilities:
+          privileged: true
+        maxRunTime: 3600
+        image: python:3.10
+        env:
+          IMAGE: mozilla/taskboot
+          REGISTRY: registry.hub.docker.com
+          VERSION: "${tag}"
+        command:
+          - sh
+          - -lxce
+          - "apt-get -qq update &&
+            apt-get -qq install -y zstd &&
+            git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b taskboot &&
+            pip install --no-cache-dir --quiet . &&
+            taskboot --target=/src build --image=$IMAGE --tag=$VERSION --write /image.tar Dockerfile"
+        artifacts:
+          public/taskboot/image.tar.zst:
+            expires: {$fromNow: '2 weeks'}
+            path: /image.tar.zst
+            type: file
+      scopes:
+        - docker-worker:capability:privileged
+      metadata:
+        name: TaskBoot docker build
+        description: Taskcluster boot utilities - build latest docker image
+        owner: bastien@mozilla.com
+        source: https://github.com/mozilla/task-boot
+
+    - taskId: {$eval: as_slugid("docker_build_test")}
       dependencies:
         - {$eval: as_slugid("code_checks")}
       provisionerId: proj-relman
@@ -86,14 +123,14 @@ tasks:
             path: image.tar.zst
             type: file
       metadata:
-        name: TaskBoot docker build using podman
+        name: TaskBoot docker build (test image)
         description: Taskcluster boot utilities - build a test image
         owner: bastien@mozilla.com
         source: https://github.com/mozilla/task-boot
 
     - taskId: {$eval: as_slugid("docker_run_podman")}
       dependencies:
-        - {$eval: as_slugid("docker_build_podman")}
+        - {$eval: as_slugid("docker_build_test")}
       provisionerId: proj-relman
       workerType: generic-worker-ubuntu-22-04
       created: {$fromNow: ''}
@@ -103,7 +140,7 @@ tasks:
         image:
           type: task-image
           path: public/taskboot/test-podman.tar.zst
-          taskId: {$eval: as_slugid("docker_build_podman")}
+          taskId: {$eval: as_slugid("docker_build_test")}
       metadata:
         name: TaskBoot docker run podman image
         description: Taskcluster boot utilities - run a test image
@@ -114,7 +151,7 @@ tasks:
       then:
         taskId: {$eval: as_slugid("docker_push")}
         dependencies:
-          - {$eval: as_slugid("docker_build_podman")}
+          - {$eval: as_slugid("docker_build")}
         provisionerId: proj-relman
         workerType: generic-worker-ubuntu-22-04
         created: {$fromNow: ''}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -63,29 +63,28 @@ tasks:
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
       payload:
-        capabilities:
-          privileged: true
         maxRunTime: 3600
-        image: python:3.10
         env:
           IMAGE: mozilla/taskboot
           REGISTRY: registry.hub.docker.com
           VERSION: "${tag}"
         command:
-          - sh
-          - -lxce
-          - "apt-get -qq update &&
-            apt-get -qq install -y zstd &&
-            git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b taskboot &&
-            pip install --no-cache-dir --quiet . &&
-            taskboot --target=/src build --image=$IMAGE --tag=$VERSION --write /image.tar Dockerfile"
+          - - sh
+            - '-lxce'
+            - |
+              wget https://bootstrap.pypa.io/get-pip.py
+              python3 get-pip.py --user
+              export PATH=$${HOME}/.local/bin:$${PATH}
+              git clone --quiet ${repository} src
+              cd src
+              git checkout ${head_rev} -b taskboot
+              python3 -m pip install --no-cache-dir --quiet --user .
+              taskboot --target=/src build --image=$${IMAGE} --tag=$${VERSION} --write ../image.tar Dockerfile
         artifacts:
-          public/taskboot/image.tar.zst:
+          - name: public/taskboot/image.tar.zst
             expires: {$fromNow: '2 weeks'}
-            path: /image.tar.zst
+            path: image.tar.zst
             type: file
-      scopes:
-        - docker-worker:capability:privileged
       metadata:
         name: TaskBoot docker build
         description: Taskcluster boot utilities - build latest docker image
@@ -116,7 +115,7 @@ tasks:
               cd src
               git checkout ${head_rev} -b taskboot
               python3 -m pip install --no-cache-dir --quiet --user .
-              taskboot --target=. build --build-tool=podman --image=$${IMAGE} --tag=$${VERSION} --write ../image.tar tests/dockerfile.empty
+              taskboot --target=. build --image=$${IMAGE} --tag=$${VERSION} --write ../image.tar tests/dockerfile.empty
         artifacts:
           - name: public/taskboot/test-podman.tar.zst
             expires: {$fromNow: '2 weeks'}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -79,7 +79,7 @@ tasks:
               cd src
               git checkout ${head_rev} -b taskboot
               python3 -m pip install --no-cache-dir --quiet --user .
-              taskboot --target=/src build --image=$${IMAGE} --tag=$${VERSION} --write ../image.tar Dockerfile
+              taskboot --target=. build --image=$${IMAGE} --tag=$${VERSION} --write ../image.tar Dockerfile
         artifacts:
           - name: public/taskboot/image.tar.zst
             expires: {$fromNow: '2 weeks'}


### PR DESCRIPTION
Taskboot v0.4.0 was accidentally built using `tests/dockerfile.empty`.