### PR TITLE
fix: remove unused cache option

### DIFF
--- a/taskboot/build.py
+++ b/taskboot/build.py
@@ -109,7 +109,7 @@ def build_compose(target, args):
     Read a compose file and build each image described as buildable
     """
     assert args.build_retries > 0, "Build retries must be a positive integer"
-    build_tool = Podman(cache=args.cache)
+    build_tool = Podman()
 
     # Check the dockerfile is available in target
     composefile = target.check_path(args.composefile)

--- a/taskboot/cli.py
+++ b/taskboot/cli.py
@@ -54,11 +54,6 @@ def main() -> None:
     parser.add_argument(
         "--target", type=str, help="Target directory to use a local project"
     )
-    parser.add_argument(
-        "--cache",
-        type=str,
-        help="Path to a local folder used to cache build processes",
-    )
     commands = parser.add_subparsers(help="sub-command help")
     parser.set_defaults(func=usage)
 

--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -191,7 +191,7 @@ class DinD(Tool):
     Interface to the Docker In Docker Taskcluster feature
     """
 
-    def __init__(self, cache=None):
+    def __init__(self):
         # Check version of remote daemon
         self.client = really_old_docker.from_env(version=TASKCLUSTER_DIND_API_VERSION)
         version = self.client.version()


### PR DESCRIPTION
Ran into that issue [here](https://community-tc.services.mozilla.com/tasks/bRJoqd5dTvqCfakcAM3jig/runs/0/logs/public/logs/live.log#L163). We'll need to remove `--cache` usages of taskboot too now.