### PR TITLE
Save images as oci-archive

### DIFF
--- a/taskboot/docker.py
+++ b/taskboot/docker.py
@@ -314,6 +314,13 @@ class Podman(Docker):
                 image["digest"] = image["digest"][7:]
         return result
 
+    def save(self, tags, path):
+        assert isinstance(tags, list)
+        assert len(tags) > 0, "Missing tags"
+        logger.info("Saving image with tags {} to {}".format(", ".join(tags), path))
+        command = ["save", "--format", "oci-archive", "--output", path] + tags
+        self.run(command)
+
 
 class Skopeo(Tool):
     """
@@ -361,7 +368,7 @@ class Skopeo(Tool):
                 "copy",
                 "--authfile",
                 self.auth_file,
-                "docker-archive:{}".format(path),
+                "oci-archive:{}".format(path),
                 "docker://{}".format(tag),
             ]
             self.run(cmd)


### PR DESCRIPTION
This means saving them compressed, which should speed up pushing them to Docker registries. E.g. we are seeing timeouts to push to Heroku (only on TC, not locally), maybe this will help.

Unfortunately I couldn't find a way to save the image with multiple tags. When I use multiple tags, the `index.json` file in the oci-archive only contains one of the tags.